### PR TITLE
Fix a typo on Nucleo F411RE doc page

### DIFF
--- a/boards/arm/nucleo_f411re/doc/nucleof411re.rst
+++ b/boards/arm/nucleo_f411re/doc/nucleof411re.rst
@@ -62,7 +62,7 @@ More information about STM32F411RE can be found here:
 Supported Features
 ==================
 
-The Zephyr nucleo_411re board configuration supports the following hardware features:
+The Zephyr nucleo_f411re board configuration supports the following hardware features:
 
 +-----------+------------+-------------------------------------+
 | Interface | Controller | Driver/Component                    |


### PR DESCRIPTION
Just a missing character, but it made me try build for a non existing board, just by chance copy pasted that wrong part from the docs.

Signed-off-by: Rouan van der Ende <rouan@8bo.org>